### PR TITLE
loosen railties version restriction

### DIFF
--- a/bootstrap-slider-rails.gemspec
+++ b/bootstrap-slider-rails.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'railties', '>= 6'
+  spec.add_dependency 'railties', '>= 5'
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
After examining the railties changelog for 5.0, 5.1, 5.2, 6.0, & 6.1, I expect that this gem is compatible with both railties 5 & 6.